### PR TITLE
Minor change on 1.2.6 fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Performs MCMCglmm on Multiple Phylogenetic Trees
 Author: Thomas Guillerme <guillert@tcd.ie> & Kevin Healy <heaylke@tcd.ie>
 Maintainer: Thomas Guillerme <guillert@tcd.ie>
 Version: 1.2.6
-Date: 2017-04-26
+Date: 2017-05-15
 Description: Allows to run a MCMCglmm on multiple phylogenetic trees to take into account phylogenetic uncertainty.
 Depends:
     R (>= 3.0.0),

--- a/R/as.mulTree.R
+++ b/R/as.mulTree.R
@@ -119,7 +119,9 @@ as.mulTree <- function(data, tree, taxa, rand.terms, clean.data = FALSE) {
                 cor_terms_list_match <- match(cor_term, colnames(data))
 
                 if(any(is.na(cor_terms_list_match))) {
-                    stop("The following random terms do not match with any column name provided in data:\n    ", paste(cor_term[is.na(cor_terms_list_match)], sep = ", "), ".", sep = "")
+                    if(cor_term[is.na(cor_terms_list_match)] != "units") {
+                        stop("The following random terms do not match with any column name provided in data:\n    ", paste(cor_term[is.na(cor_terms_list_match)], sep = ", "), ".", sep = "")
+                    }
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -37,9 +37,12 @@ install.packages(c("MCMCglmm", "coda", "hdrcde", "snow", "ape", "corpcor", "curl
 *  An additional example of running simple phylogenetic models is [here](https://github.com/TGuillerme/mulTree/blob/master/doc/Vanilla_flavoured_phylogenetic_analyses.Rmd).
 
 ##### Patch notes (latest version)
-* 2017/04/26 - v1.2.6
+* 2017/05/15 - v1.2.6
   * Removed `caper` dependencies.
   * Minor fixes to code internal documentation.
+  * `coda::gelman.diag` in `mulTree` now only outputs a warning rather than a stop message
+  * Allows R-structure's standrad multi-response model in `as.mulTree` (e.g. `rand.terms  = ~taxa + specimen + us(trait):observation`).
+
   
 Previous patch notes and the *next version* ones can be seen [here](https://github.com/TGuillerme/mulTree/blob/master/patch_notes.md).
 

--- a/patch_notes.md
+++ b/patch_notes.md
@@ -1,6 +1,6 @@
 Patch notes
 ----
-* 2017/04/26 - v1.2.6
+* 2017/05/15 - v1.2.6
   * Removed `caper` dependencies.
   * Minor fixes to code internal documentation.
   * `coda::gelman.diag` in `mulTree` now only outputs a warning rather than a stop message


### PR DESCRIPTION
Add exception for `units` in correlation `random.terms` in `as.mulTree`.