### PR TITLE
Allow import of more than 9 chains

### DIFF
--- a/R/read.mulTree.R
+++ b/R/read.mulTree.R
@@ -57,11 +57,11 @@ read.mulTree <- function(mulTree.chain, convergence = FALSE, model = FALSE, extr
     scanned_chains <- list.files(pattern = mulTree.chain)
 ##     check.length(scanned_chains, 0, " files not found in current directory.", errorif = TRUE)
     if(length(scanned_chains) == 1) {
-        if(length(grep("chain[0-9].rda", scanned_chains)) == 0) {
+        if(length(grep("chain[0-9]+\\.rda$", scanned_chains)) == 0) {
             stop("File \"", mulTree.chain, "\" is not a mulTree chain but a single file.", sep="",call.=FALSE)
         }
     } else {
-        if(length(grep("chain[0-9].rda", scanned_chains)) == 0) {
+        if(length(grep("chain[0-9]+\\.rda$", scanned_chains)) == 0) {
             stop("File \"", mulTree.chain, "\" not found in current directory.", sep="",call.=FALSE)
         }
     }


### PR DESCRIPTION
Hi,

I had some issues with `mulTree` in an example where I used 12 chains. The current regex doesn't allow more than 9 chains. 6effc3a fixes this.

I also had some issues while running `devtools::check()` on this branch. 4eab2a1 removes broken characters that prevented the checks to run. Even then, I have multiple errors when running `devtools::check()` but I don't think they're related to my changes. Let me know if you think differently.

While doing these changes, I also noticed that numerous `stop()`s and `warning()`s have an unused `sep = ""` argument:

```{r}
# These two calls return the same string
message("Hello", "world")
message("Hello", "world", sep = "")
```

and sometime wrap an unnecessary `paste()`. From `?message`:

> zero or more objects which can be coerced to character (and which are pasted together with no separator)

Please let me know if you'd prefer multiple PR for these changes. Thanks.